### PR TITLE
Fix issue with incorrectly processed signed payload in pre-signed URL

### DIFF
--- a/src/Signature/S3SignatureV4.php
+++ b/src/Signature/S3SignatureV4.php
@@ -38,20 +38,11 @@ class S3SignatureV4 extends SignatureV4
         if (!$request->hasHeader('x-amz-content-sha256')) {
             $request = $request->withHeader(
                 'X-Amz-Content-Sha256',
-                $this->getPresignedPayload($request)
+                SignatureV4::UNSIGNED_PAYLOAD
             );
         }
 
         return parent::presign($request, $credentials, $expires, $options);
-    }
-
-    /**
-     * Override used to allow pre-signed URLs to be created for an
-     * in-determinate request payload.
-     */
-    protected function getPresignedPayload(RequestInterface $request)
-    {
-        return SignatureV4::UNSIGNED_PAYLOAD;
     }
 
     /**


### PR DESCRIPTION
Solving for issue https://github.com/aws/aws-sdk-php/issues/1581
Original pull request https://github.com/aws/aws-sdk-php/pull/1584

Fixing of a problem in issue https://github.com/aws/aws-sdk-php/issues/1581 with a checksum of the uploaded file providing `ContentSha256` param in command for creating pre-signed URL.